### PR TITLE
Add directory details to the package.json of all our own packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "codesandbox-templates",
   "version": "0.0.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-templates"
+  },
   "installConfig": {
     "pnp": true
   }

--- a/packages/template-icons/package.json
+++ b/packages/template-icons/package.json
@@ -13,7 +13,11 @@
     "Sara Vieira <sara@codesandbox.io> (https://github.com/SaraVieira)"
   ],
   "homepage": "https://codesandbox.io/",
-  "repository": "https://github.com/codesandbox/codesandbox-templates/tree/master/packages/template-icons",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codesandbox/codesandbox-templates",
+    "directory": "packages/template-icons"
+  },
   "bugs": "https://github.com/codesandbox/codesandbox-templates/issues",
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Just like codesandbox/codesandbox-client#2167

Specifying the directory as part of the `repository` field in a `package.json` allows third party tools to provide better support when working with monorepos. For example, it allows them to correctly construct a commit diff for a specific package.

This format was accepted by `npm` in npm/rfcs#19.